### PR TITLE
Removed old READ_MEDIA_IMAGES and READ_MEDIA_VIDEO permissions.

### DIFF
--- a/demo-lib/src/main/AndroidManifest.xml
+++ b/demo-lib/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:tools="http://schemas.android.com/tools"
+	xmlns:android="http://schemas.android.com/apk/res/android">
 
 	<uses-permission android:name="android.permission.CAMERA"/>
 	<uses-permission android:name="android.permission.INTERNET" />
@@ -9,8 +10,6 @@
 	<uses-permission
 		android:name="android.permission.READ_EXTERNAL_STORAGE"
 		android:maxSdkVersion="28" />
-	<uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-	<uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
 
 	<uses-feature
 		android:name="android.hardware.camera.any"
@@ -25,7 +24,8 @@
 		<activity
 			android:name=".chat.ChatActivity"
 			android:exported="false"
-			android:screenOrientation="portrait"/>
+			android:screenOrientation="portrait"
+			tools:ignore="DiscouragedApi" />
 
 		<activity
 			android:name=".chat.image.ImageActivity"
@@ -36,7 +36,8 @@
 		<activity
 			android:name="com.yalantis.ucrop.UCropActivity"
 			android:screenOrientation="portrait"
-			android:theme="@style/Theme.MaterialComponents.Light.NoActionBar" />
+			android:theme="@style/Theme.MaterialComponents.Light.NoActionBar"
+			tools:ignore="DiscouragedApi"/>
 
 		<provider
 			android:name="ru.livetex.sdkui.LivetexFileProvider"
@@ -47,6 +48,21 @@
 				android:name="android.support.FILE_PROVIDER_PATHS"
 				android:resource="@xml/provider_paths" />
 		</provider>
+
+		<!--
+			Prompt Google Play services to install the backported photo picker module
+			https://developer.android.com/training/data-storage/shared/photopicker#device-availability
+		-->
+		<!--suppress AndroidDomInspection -->
+		<service android:name="com.google.android.gms.metadata.ModuleDependencies"
+			android:enabled="false"
+			android:exported="false"
+			tools:ignore="MissingClass">
+			<intent-filter>
+				<action android:name="com.google.android.gms.metadata.MODULE_DEPENDENCIES" />
+			</intent-filter>
+			<meta-data android:name="photopicker_activity:0:required" android:value="" />
+		</service>
 	</application>
 
 	<queries>


### PR DESCRIPTION
They are old and Google put notable limitations on them. It shouldn't affect media picker functionality.
See https://android-developers.googleblog.com/2023/04/photo-picker-everywhere.html for more info